### PR TITLE
Fix clippy lints & rustfmt

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -365,7 +365,7 @@ pub fn run(args: Opt) -> Result<(), Box<dyn Error>> {
         fs::canonicalize(path)?
     };
 
-    let maybe_patch = |shouldnt_patch, predicate: &Box<dyn Fn(&Package) -> bool>| {
+    let maybe_patch = |shouldnt_patch, predicate: &dyn Fn(&Package) -> bool| {
         if shouldnt_patch {
             return Ok(());
         }
@@ -415,9 +415,7 @@ pub fn run(args: Opt) -> Result<(), Box<dyn Error>> {
             }
             let predicate = make_pkg_predicate(pkg_opts)?;
             let type_value = {
-                if &value == "true" {
-                    Value::from(true)
-                } else if &value == "false" {
+                if &value == "true" || &value == "false" {
                     Value::from(true)
                 } else if let Ok(v) = i64::from_str(&value) {
                     Value::from(v)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,7 +299,7 @@ fn make_pkg_predicate(args: PackageSelectOptions) -> Result<Box<dyn Fn(&Package)
         ignore_publish,
     } = args;
 
-    if !packages.is_empty()&& (!skip.is_empty() || !ignore_pre_version.is_empty()) {
+    if !packages.is_empty() && (!skip.is_empty() || !ignore_pre_version.is_empty()) {
         return Err(
             "-p/--packages is mutually exlusive to using -s/--skip and -i/--ignore-version-pre"
                 .into(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,13 +299,11 @@ fn make_pkg_predicate(args: PackageSelectOptions) -> Result<Box<dyn Fn(&Package)
         ignore_publish,
     } = args;
 
-    if !packages.is_empty() {
-        if !skip.is_empty() || !ignore_pre_version.is_empty() {
-            return Err(
-                "-p/--packages is mutually exlusive to using -s/--skip and -i/--ignore-version-pre"
-                    .into(),
-            );
-        }
+    if !packages.is_empty()&& (!skip.is_empty() || !ignore_pre_version.is_empty()) {
+        return Err(
+            "-p/--packages is mutually exlusive to using -s/--skip and -i/--ignore-version-pre"
+                .into(),
+        );
     }
 
     let publish = move |p: &Package| {
@@ -333,7 +331,7 @@ fn make_pkg_predicate(args: PackageSelectOptions) -> Result<Box<dyn Fn(&Package)
                 return false;
             }
             let name = p.name();
-            if skip.iter().find(|r| r.is_match(&name)).is_some() {
+            if skip.iter().any(|r| r.is_match(&name)) {
                 return false;
             }
             if p.version().is_prerelease() {
@@ -412,7 +410,7 @@ pub fn run(args: Opt) -> Result<(), Box<dyn Error>> {
             value,
             pkg_opts,
         } => {
-            if name == "name".to_owned() {
+            if name == "name" {
                 return Err("To change the name please use the rename command!".into());
             }
             let predicate = make_pkg_predicate(pkg_opts)?;

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -10,9 +10,9 @@ use cargo::{
     sources::PathSource,
     util::{paths, FileLock},
 };
-use semver::VersionReq;
 use flate2::read::GzDecoder;
 use log::error;
+use semver::VersionReq;
 use std::{
     collections::HashMap,
     error::Error,
@@ -231,7 +231,11 @@ pub fn check<'a>(
             res.push(format!("{:}: Bad metadata: {:}", pkg.name(), e));
         }
         if let Err(e) = check_dependencies(pkg) {
-            res.push(format!("{:}: has dependencies defined as git without a version: {:}", pkg.name(), e));
+            res.push(format!(
+                "{:}: has dependencies defined as git without a version: {:}",
+                pkg.name(),
+                e
+            ));
         }
         res
     });
@@ -243,7 +247,11 @@ pub fn check<'a>(
     let errors_count = errors.len();
 
     if !errors.is_empty() {
-        return Err(format!("Soft checkes failed with {} errors (see above)", errors_count).into());
+        return Err(format!(
+            "Soft checkes failed with {} errors (see above)",
+            errors_count
+        )
+        .into());
     }
 
     let builds = packages.iter().map(|pkg| {

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -24,7 +24,7 @@ fn check_for_update<'a>(
             trace!("We renamed {:} to {:}", name, new_name);
             info.get_or_insert(
                 " package",
-                decorated(Value::from(format!("{:}", new_name)), " ", " "),
+                decorated(Value::from(new_name.to_string()), " ", " "),
             );
             DependencyAction::Mutated
         }
@@ -34,7 +34,7 @@ fn check_for_update<'a>(
             }
 
             info["package"] =
-                Item::Value(decorated(Value::from(format!("{:}", new_name)), " ", ""));
+                Item::Value(decorated(Value::from(new_name.to_string()), " ", ""));
             DependencyAction::Mutated
         }
     }
@@ -66,7 +66,7 @@ where
     .filter_map(|s| s)
     .collect::<HashMap<_, _>>();
 
-    if updates.len() == 0 {
+    if updates.is_empty() {
         c.shell().status("Done", "No changed applied")?;
         return Ok(());
     }

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -33,8 +33,7 @@ fn check_for_update<'a>(
                 return DependencyAction::Untouched; // entry isn't local
             }
 
-            info["package"] =
-                Item::Value(decorated(Value::from(new_name.to_string()), " ", ""));
+            info["package"] = Item::Value(decorated(Value::from(new_name.to_string()), " ", ""));
             DependencyAction::Mutated
         }
     }

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -26,7 +26,7 @@ fn check_for_update<'a>(
                 " package",
                 decorated(Value::from(format!("{:}", new_name)), " ", " "),
             );
-            return DependencyAction::Mutated;
+            DependencyAction::Mutated
         }
         DependencyEntry::Table(info) => {
             if !info.contains_key("path") {
@@ -35,7 +35,7 @@ fn check_for_update<'a>(
 
             info["package"] =
                 Item::Value(decorated(Value::from(format!("{:}", new_name)), " ", ""));
-            return DependencyAction::Mutated;
+            DependencyAction::Mutated
         }
     }
 }
@@ -58,7 +58,7 @@ where
                     .expect("Writing to the shell would have failed before. qed");
                 doc["package"]["name"] =
                     Item::Value(decorated(Value::from(new_name.to_string()), " ", ""));
-                (p.name().as_str().to_owned(), new_name.clone())
+                (p.name().as_str().to_owned(), new_name)
             }))
         },
     )?

--- a/src/commands/to_release.rs
+++ b/src/commands/to_release.rs
@@ -101,7 +101,7 @@ where
         .rev()
         .collect::<Vec<_>>();
 
-    if packages.len() == 0 {
+    if packages.is_empty() {
         return Err("No Packages matching criteria. Exiting".into());
     }
 

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -28,7 +28,7 @@ fn check_for_update<'a>(
             if let Some(v_req) = info.get_mut("version") {
                 let r = v_req
                     .as_str()
-                    .ok_or("Version must be string".to_owned())
+                    .ok_or_else(|| "Version must be string".to_owned())
                     .and_then(|s| {
                         VersionReq::parse(s).map_err(|e| format!("Parsing failed {:}", e))
                     })
@@ -59,7 +59,7 @@ fn check_for_update<'a>(
                 if let Some(v_req) = info.get("version") {
                     let r = v_req
                         .as_str()
-                        .ok_or("Version must be string".to_owned())
+                        .ok_or_else(|| "Version must be string".to_owned())
                         .and_then(|s| {
                             VersionReq::parse(s).map_err(|e| format!("Parsing failed {:}", e))
                         })
@@ -106,7 +106,7 @@ where
                     .expect("Writing to the shell would have failed before. qed");
                 doc["package"]["version"] =
                     Item::Value(decorated(Value::from(nv_version.to_string()), " ", ""));
-                (p.name().as_str().to_owned(), nv_version.clone())
+                (p.name().as_str().to_owned(), nv_version)
             }))
         },
     )?

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,7 +14,7 @@ pub fn members_deep<'a>(ws: &'a Workspace) -> Vec<Package> {
     for m in ws.members() {
         total_list.push(m.clone());
         for dep in m.dependencies() {
-            let source = dep.source_id().clone();
+            let source = dep.source_id();
             if source.is_path() {
                 let dst = source
                     .url()
@@ -68,7 +68,7 @@ pub enum DependencyAction {
 /// Iterate through the dependency sections of root, find each
 /// dependency entry, that is a subsection and hand it and its name
 /// to f. Return the counter of how many times f returned true.
-pub fn edit_each_dep<'a, F>(root: &'a mut Table, f: F) -> u32
+pub fn edit_each_dep<F>(root: &mut Table, f: F) -> u32
 where
     F: Fn(String, Option<String>, DependencyEntry) -> DependencyAction,
 {
@@ -96,7 +96,7 @@ where
             let (name, action) = match t.entry(&key) {
                 Item::Value(Value::InlineTable(info)) => {
                     let (name, alias) = {
-                        if let Some(name) = info.get("package").clone() {
+                        if let Some(name) = info.get("package") {
                             // is there a rename
                             (name
                                 .as_str()
@@ -111,7 +111,7 @@ where
                 }
                 Item::Table(info) => {
                     let (name, alias) = {
-                        if let Some(name) = info.get("package").clone() {
+                        if let Some(name) = info.get("package") {
                             // is there a rename
                             (name
                                 .as_str()
@@ -239,7 +239,7 @@ async fn fetch_cratesio_versions(
         .into_iter()
         .partition(|(_, r)| r.is_ok());
 
-    if failures.len() > 0 {
+    if !failures.is_empty() {
         return Err(format!(
             "Failure fetching crates versions: {:}",
             failures

--- a/src/util.rs
+++ b/src/util.rs
@@ -74,7 +74,7 @@ where
 {
     let mut counter = 0;
     let mut removed = Vec::new();
-    for k in vec!["dependencies", "dev-dependencies", "build-dependencies"] {
+    for k in &["dependencies", "dev-dependencies", "build-dependencies"] {
         let keys = {
             if let Some(Item::Table(t)) = &root.get(k) {
                 t.iter()
@@ -152,7 +152,7 @@ where
                     let mut to_remove = Vec::new();
                     for (idx, dep) in deps.iter().enumerate() {
                         if let Value::String(s) = dep {
-                            if let Some(s) = s.value().trim().split("/").next() {
+                            if let Some(s) = s.value().trim().split('/').next() {
                                 if removed.contains(&s.to_owned()) {
                                     to_remove.push(idx);
                                 }
@@ -231,8 +231,7 @@ async fn fetch_cratesio_versions(
 
     let fts = crates.into_iter().map(move |name| {
         let c = client.clone();
-        let n = name.to_string();
-        fetch(c, n.clone()).map(move |r| (n, r))
+        fetch(c, name.clone()).map(move |r| (name, r))
     });
 
     let (success, failures): (Vec<_>, Vec<_>) = futures::future::join_all(fts)
@@ -253,6 +252,6 @@ async fn fetch_cratesio_versions(
 
     Ok(success
         .into_iter()
-        .map(move |(name, r)| (name.clone(), r.expect("We partioned based on error")))
+        .map(move |(name, r)| (name, r.expect("We partioned based on error")))
         .collect::<HashMap<String, _>>())
 }


### PR DESCRIPTION
Not much to say, this PR fixes the clippy warnings that popped up after running `cargo clippy --all`, and formats the code base using the standard `cargo fmt` :)