### PR TITLE
Streamline package selection predicate

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -341,7 +341,7 @@ pub struct Opt {
     pub cmd: Command,
 }
 
-fn make_pkg_predicate(args: PackageSelectOptions) -> Result<Box<dyn Fn(&Package) -> bool>, String> {
+fn make_pkg_predicate(args: PackageSelectOptions) -> Result<impl Fn(&Package) -> bool, String> {
     let PackageSelectOptions {
         packages,
         skip,
@@ -368,18 +368,17 @@ fn make_pkg_predicate(args: PackageSelectOptions) -> Result<Box<dyn Fn(&Package)
         publ
     };
 
-    if !packages.is_empty() {
-        trace!("going for matching against {:?}", packages);
-        return Ok(Box::new(move |p: &Package| {
-            publish(p) && packages.contains(&p.name())
-        }));
-    }
+    Ok(move |p: &Package| {
+        if !publish(p) {
+            return false;
+        }
 
-    if !skip.is_empty() || !ignore_pre_version.is_empty() {
-        return Ok(Box::new(move |p: &Package| {
-            if !publish(p) {
-                return false;
-            }
+        if !packages.is_empty() {
+            trace!("going for matching against {:?}", packages);
+            return packages.contains(&p.name());
+        }
+
+        if !skip.is_empty() || !ignore_pre_version.is_empty() {
             let name = p.name();
             if skip.iter().any(|r| r.is_match(&name)) {
                 return false;
@@ -391,11 +390,10 @@ fn make_pkg_predicate(args: PackageSelectOptions) -> Result<Box<dyn Fn(&Package)
                     }
                 }
             }
-            true
-        }));
-    }
+        }
 
-    Ok(Box::new(publish))
+        true
+    })
 }
 
 fn verify_readme_feature() -> Result<(), String> {


### PR DESCRIPTION
This groups package selection logic in one place, reducing the need for
boxing the resulting closure and making it easier to reason locally
about the package selection.

This should be (hopefully!) identical to the previous version, with the exception of not `trace!`ing the debug message if a package is already not marked for publish.