### PR TITLE
Add `version bump-breaking` cli  command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -611,7 +611,17 @@ pub fn run(args: Opt) -> Result<(), Box<dyn Error>> {
                             let mut v = p.version().clone();
                             v.pre = Vec::new();
                             if v.major == 0 {
-                                v.increment_minor();
+                                if v.minor == 0 {
+                                    // 0.0.x means each patch is breaking, see:
+                                    // https://doc.rust-lang.org/cargo/reference/semver.html#change-categories
+
+                                    v.patch += 1;
+                                    // no helper, have to reset the metadata ourselves
+                                    v.build = Vec::new();
+                                    v.pre = Vec::new();
+                                } else {
+                                    v.increment_minor();
+                                }
                             } else {
                                 v.increment_major();
                             }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -619,7 +619,7 @@ pub fn run(args: Opt) -> Result<(), Box<dyn Error>> {
                         },
                         force_update,
                     )
-                },
+                }
                 VersionCommand::SetPre {
                     pre,
                     pkg_opts,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -610,20 +610,18 @@ pub fn run(args: Opt) -> Result<(), Box<dyn Error>> {
                         |p| {
                             let mut v = p.version().clone();
                             v.pre = Vec::new();
-                            if v.major == 0 {
-                                if v.minor == 0 {
-                                    // 0.0.x means each patch is breaking, see:
-                                    // https://doc.rust-lang.org/cargo/reference/semver.html#change-categories
-
-                                    v.patch += 1;
-                                    // no helper, have to reset the metadata ourselves
-                                    v.build = Vec::new();
-                                    v.pre = Vec::new();
-                                } else {
-                                    v.increment_minor();
-                                }
-                            } else {
+                            if v.major != 0 {
                                 v.increment_major();
+                            } else if v.minor != 0 {
+                                v.increment_minor();
+                            } else {
+                                // 0.0.x means each patch is breaking, see:
+                                // https://doc.rust-lang.org/cargo/reference/semver.html#change-categories
+
+                                v.patch += 1;
+                                // no helper, have to reset the metadata ourselves
+                                v.build = Vec::new();
+                                v.pre = Vec::new();
                             }
                             Some(v)
                         },


### PR DESCRIPTION
doing smart version updates on semver-breaking-level: bump 0.x to the next minor and x.0 where x >= 1 next major.

In substrate we have 0.8 and 2.0.1 and both need updating to their next breaking level. This command now nicely does that.