### PR TITLE
enable nightly features

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -399,6 +399,7 @@ fn verify_readme_feature() -> Result<(), String> {
 }
 
 pub fn run(args: Opt) -> Result<(), Box<dyn Error>> {
+    cargo::core::features::enable_nightly_features();
     let _ = Logger::with_str(args.log.clone()).start();
     let c = CargoConfig::default().expect("Couldn't create cargo config");
     c.shell().set_verbosity(if args.verbose {


### PR DESCRIPTION
This is required to allow us use resolver 2, which is used by ORML to fix deps resolution issue with dev-dependencies

Let me know if you want me to put this behind a CLI flag or if there is better way to deal with it.

https://github.com/open-web3-stack/open-runtime-module-library/blob/master/Cargo.dev.toml