### PR TITLE
don't update dev dependency without a version number

### DIFF
--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -34,7 +34,7 @@ fn inject_replacement(
     let mut document = document.parse::<Document>()?;
     let root = document.as_table_mut();
 
-    edit_each_dep(root, |name, _, entry| {
+    edit_each_dep(root, |name, _, entry, _| {
         if let Some(p) = replace.get(&name) {
             let path = Value::from(p.clone()).decorated(" ", " ");
             match entry {

--- a/src/commands/clean_deps.rs
+++ b/src/commands/clean_deps.rs
@@ -20,7 +20,7 @@ where
             c.shell().status("Checking", p.name())?;
             let source_path = p.root();
             let root = doc.as_table_mut();
-            Ok(edit_each_dep(root, |p_name, alias, _table| {
+            Ok(edit_each_dep(root, |p_name, alias, _table, _| {
                 let name = alias.unwrap_or(p_name);
                 let found = Command::new("rg")
                     .args(&["--type", "rust"])

--- a/src/commands/clean_deps.rs
+++ b/src/commands/clean_deps.rs
@@ -25,7 +25,7 @@ where
                 let found = Command::new("rg")
                     .args(&["--type", "rust"])
                     .arg("-qw")
-                    .arg(name.replace("-", "_"))
+                    .arg(name.replace('-', "_"))
                     .arg(&source_path)
                     .status()
                     .unwrap()

--- a/src/commands/rename.rs
+++ b/src/commands/rename.rs
@@ -77,7 +77,7 @@ where
         c.shell().status("Updating", p.name())?;
         let root = doc.as_table_mut();
         let mut updates_count = 0;
-        updates_count += edit_each_dep(root, |a, _, b| check_for_update(a, b, &updates));
+        updates_count += edit_each_dep(root, |a, _, b, _| check_for_update(a, b, &updates));
 
         if let Some(Item::Table(table)) = root.get_mut("target") {
             let keys = table
@@ -94,7 +94,7 @@ where
             for k in keys {
                 if let Some(Item::Table(root)) = table.get_mut(&k) {
                     updates_count +=
-                        edit_each_dep(root, |a, _, b| check_for_update(a, b, &updates));
+                        edit_each_dep(root, |a, _, b, _| check_for_update(a, b, &updates));
                 }
             }
         }

--- a/src/commands/to_release.rs
+++ b/src/commands/to_release.rs
@@ -208,9 +208,7 @@ fn graphviz<'i, I: IntoIterator<Item = &'i Vec<NodeIndex>>, W: Write>(
     dest: &mut W,
 ) -> anyhow::Result<()> {
     let cycle_indices = cycles
-        .into_iter()
-        .map(|y| y.iter())
-        .flatten()
+        .into_iter().flat_map(|y| y.iter())
         .copied()
         .collect::<HashSet<_>>();
     let config = &[dot::Config::EdgeNoLabel, dot::Config::NodeNoLabel][..];

--- a/src/commands/to_release.rs
+++ b/src/commands/to_release.rs
@@ -208,7 +208,8 @@ fn graphviz<'i, I: IntoIterator<Item = &'i Vec<NodeIndex>>, W: Write>(
     dest: &mut W,
 ) -> anyhow::Result<()> {
     let cycle_indices = cycles
-        .into_iter().flat_map(|y| y.iter())
+        .into_iter()
+        .flat_map(|y| y.iter())
         .copied()
         .collect::<HashSet<_>>();
     let config = &[dot::Config::EdgeNoLabel, dot::Config::NodeNoLabel][..];

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -1,4 +1,6 @@
-use crate::util::{edit_each, edit_each_dep, members_deep, DependencyAction, DependencyEntry, DependencySection};
+use crate::util::{
+    edit_each, edit_each_dep, members_deep, DependencyAction, DependencyEntry, DependencySection,
+};
 use anyhow::Context;
 use cargo::core::{package::Package, Workspace};
 use log::trace;
@@ -40,7 +42,7 @@ fn check_for_update(
                 }
             } else if section == DependencySection::Dev {
                 trace!("No version found on dev dependency, ignoring.");
-                return DependencyAction::Untouched
+                return DependencyAction::Untouched;
             } else {
                 // not yet present, we force set.
                 trace!("No version found, setting.");
@@ -71,7 +73,7 @@ fn check_for_update(
                     trace!("Versions don't match anymore, updating.");
                 } else if section == DependencySection::Dev {
                     trace!("No version found on dev dependency, ignoring.");
-                    return DependencyAction::Untouched
+                    return DependencyAction::Untouched;
                 } else {
                     trace!("No version found, setting.");
                 }

--- a/src/commands/version.rs
+++ b/src/commands/version.rs
@@ -72,7 +72,7 @@ fn check_for_update(
                     }
                     trace!("Versions don't match anymore, updating.");
                 } else if section == DependencySection::Dev {
-                    trace!("No version found on dev dependency, ignoring.");
+                    trace!("No version found on dev dependency {:}, ignoring.", name);
                     return DependencyAction::Untouched;
                 } else {
                     trace!("No version found, setting.");
@@ -125,8 +125,8 @@ where
         c.shell().status("Updating", p.name())?;
         let root = doc.as_table_mut();
         let mut updates_count = 0;
-        updates_count += edit_each_dep(root, |a, _, b, c| {
-            check_for_update(a, b, &updates, c, force_update)
+        updates_count += edit_each_dep(root, |name, _, wrap, section| {
+            check_for_update(name, wrap, &updates, section, force_update)
         });
 
         if let Entry::Occupied(occupied) = root.entry("target") {

--- a/src/util.rs
+++ b/src/util.rs
@@ -145,7 +145,11 @@ where
 {
     let mut counter = 0;
     let mut removed = Vec::new();
-    for case in [DependencySection::Regular, DependencySection::Dev, DependencySection::Build] {
+    for case in [
+        DependencySection::Regular,
+        DependencySection::Dev,
+        DependencySection::Build,
+    ] {
         let k = case.key();
         let keys = {
             if let Some(Item::Table(t)) = &root.get(k) {
@@ -183,7 +187,10 @@ where
                             (key.clone(), None)
                         }
                     };
-                    (name.clone(), f(name, alias, DependencyEntry::Inline(info), case.clone()))
+                    (
+                        name.clone(),
+                        f(name, alias, DependencyEntry::Inline(info), case.clone()),
+                    )
                 }
                 Some(Item::Table(info)) => {
                     let (name, alias) = {
@@ -199,7 +206,10 @@ where
                         }
                     };
 
-                    (name.clone(), f(name, alias, DependencyEntry::Table(info), case.clone()))
+                    (
+                        name.clone(),
+                        f(name, alias, DependencyEntry::Table(info), case.clone()),
+                    )
                 }
                 None => {
                     continue;

--- a/src/util.rs
+++ b/src/util.rs
@@ -115,16 +115,38 @@ pub enum DependencyAction {
     Remove,
 }
 
+#[derive(Debug, PartialEq, Clone)]
+/// Which Dependency Section a dependency belongs to
+pub enum DependencySection {
+    /// Just a regular `dependency`
+    Regular,
+    /// A `dev-`dependency
+    Dev,
+    /// A build dependency
+    Build,
+}
+
+impl DependencySection {
+    fn key(&self) -> &'static str {
+        match self {
+            DependencySection::Regular => "dependencies",
+            DependencySection::Dev => "dev-dependencies",
+            DependencySection::Build => "build-dependencies",
+        }
+    }
+}
+
 /// Iterate through the dependency sections of root, find each
 /// dependency entry, that is a subsection and hand it and its name
 /// to f. Return the counter of how many times f returned true.
 pub fn edit_each_dep<F>(root: &mut Table, f: F) -> u32
 where
-    F: Fn(String, Option<String>, DependencyEntry) -> DependencyAction,
+    F: Fn(String, Option<String>, DependencyEntry, DependencySection) -> DependencyAction,
 {
     let mut counter = 0;
     let mut removed = Vec::new();
-    for k in &["dependencies", "dev-dependencies", "build-dependencies"] {
+    for case in [DependencySection::Regular, DependencySection::Dev, DependencySection::Build] {
+        let k = case.key();
         let keys = {
             if let Some(Item::Table(t)) = &root.get(k) {
                 t.iter()
@@ -161,7 +183,7 @@ where
                             (key.clone(), None)
                         }
                     };
-                    (name.clone(), f(name, alias, DependencyEntry::Inline(info)))
+                    (name.clone(), f(name, alias, DependencyEntry::Inline(info), case.clone()))
                 }
                 Some(Item::Table(info)) => {
                     let (name, alias) = {
@@ -177,7 +199,7 @@ where
                         }
                     };
 
-                    (name.clone(), f(name, alias, DependencyEntry::Table(info)))
+                    (name.clone(), f(name, alias, DependencyEntry::Table(info), case.clone()))
                 }
                 None => {
                     continue;


### PR DESCRIPTION
`dev-dependencies` that have only a `path` defined are ignored by cargo publish/crates.io nowadays for convienience. Following this pattern we should not be forcing a version number into `dev-dependencies` on `version`-upgrades if there wasn't any before.